### PR TITLE
Add Security Policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,3 @@
-blank_issues_enabled: true
 contact_links:
   - name: Security Reporting
     url: mailto:security@meltwater.com

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Reporting
+    url: mailto:security@meltwater.com
+    about: Please report security vulnerabilities here.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+Thank you for helping us to keep our Open Source projects secure. We really appreciate it!
+
+To help us keep the community secure, please send an email to security@meltwater.com to report a security vulnerability. 
+We will coordinate the mitigation process and the eventual public disclosure from there. 


### PR DESCRIPTION
Guide members of the open source community on how on to handle responsible disclosure with regard's to Meltwater's public repositories.